### PR TITLE
ci: add workflow_dispatch trigger to CD pipeline

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,6 +1,7 @@
 name: CD Pipeline
 
 on:
+  workflow_dispatch:
   workflow_run:
     workflows: ["CI Pipeline"]
     types:


### PR DESCRIPTION
Allows manual triggering of the CD workflow via 'gh workflow run cd.yml --ref main' for testing and debugging.